### PR TITLE
Fix typo on "setPersistSettings" js sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ client.setEnvironment('mypurecloud.ie');
 In a web environment, it is possible to persist the access token to prevent an authentication request from being made on each page load. To enable this function, simply enable settings persistence prior to attempting a login. To maintain multiple auth tokens in storage, specify the prefix to use for storage/retrieval when enabling persistence. Otherwise, the prefix is optional and will default to `purecloud`.
 
 ~~~ js
+// Browser
+const platformClient = require('platformClient');
+// Node
 const platformClient = require('purecloud-platform-client-v2');
 
 var client = platformClient.ApiClient.instance;

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ client.setEnvironment('mypurecloud.ie');
 In a web environment, it is possible to persist the access token to prevent an authentication request from being made on each page load. To enable this function, simply enable settings persistence prior to attempting a login. To maintain multiple auth tokens in storage, specify the prefix to use for storage/retrieval when enabling persistence. Otherwise, the prefix is optional and will default to `purecloud`.
 
 ~~~ js
-const platformClient = require('platformClient');
-var client = purecloud-platform-client-v2.ApiClient.instance;
+const platformClient = require('purecloud-platform-client-v2');
+
+var client = platformClient.ApiClient.instance;
 client.setPersistSettings(true, 'optional_prefix');
 ~~~
 


### PR DESCRIPTION
There is a typo on the example code showing how to use the "setPersistSettings" feature.
This is in the "Access Token persistence" section.