### PR TITLE
Make persist setting prefix argument optional

### DIFF
--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -16,7 +16,7 @@ declare class ApiClientClass {
 	setAccessToken(token: string): void;
 	setDebugLog(debugLog: any, maxLines: number): void;
 	setEnvironment(environment: string): void;
-	setPersistSettings(doPersist: boolean, prefix: string): void;
+	setPersistSettings(doPersist: boolean, prefix?: string): void;
 	setReturnExtendedResponses(returnExtended: boolean): void;
 	setStorageKey(storageKey: string): void;
 }


### PR DESCRIPTION
When using `setPersistSettings` without second optional argument, `typescript` throw error, while this is correct usage.
![image](https://user-images.githubusercontent.com/33541009/74157416-f0276700-4c20-11ea-9519-c5cd59d94fbd.png)
