### PR TITLE
Add conditional check for `fs` usage in web context

### DIFF
--- a/build/src/purecloud-platform-client-v2/configuration.js
+++ b/build/src/purecloud-platform-client-v2/configuration.js
@@ -41,27 +41,29 @@ class Configuration {
 	}
 
 	liveLoadConfig() {
-		// If in browser, don't read config file, use default values
-		if (typeof window !== 'undefined') {
-			this.configPath = '';
+		if (typeof window === 'undefined') {
+			// Please don't remove the typeof window === 'undefined' check here!
+			// This safeguards the browser environment from using `fs`, which is only
+			// available in node environment.
+			this.updateConfigFromFile();
+
+			if (this.live_reload_config && this.live_reload_config === true) {
+				try {
+					const fs = require('fs');
+					fs.watchFile(this.configPath, { persistent: false }, (eventType, filename) => {
+						this.updateConfigFromFile();
+						if (!this.live_reload_config) {
+							fs.unwatchFile(this.configPath);
+						}
+					});
+				} catch (err) {
+					// do nothing
+				}
+			}
 			return;
 		}
-
-		this.updateConfigFromFile();
-
-		if (this.live_reload_config && this.live_reload_config === true) {
-			try {
-				const fs = require('fs');
-				fs.watchFile(this.configPath, { persistent: false }, (eventType, filename) => {
-					this.updateConfigFromFile();
-					if (!this.live_reload_config) {
-						fs.unwatchFile(this.configPath);
-					}
-				});
-			} catch (err) {
-				// do nothing
-			}
-		}
+		// If in browser, don't read config file, use default values
+		this.configPath = '';
 	}
 
 	setConfigPath(path) {
@@ -72,24 +74,29 @@ class Configuration {
 	}
 
 	updateConfigFromFile() {
-		const ConfigParser = require('configparser');
+		if (typeof window === 'undefined') {
+			// Please don't remove the typeof window === 'undefined' check here!
+			// This safeguards the browser environment from using `fs`, which is only
+			// available in node environment.
+			const ConfigParser = require('configparser');
 
-		try {
-			var configparser = new ConfigParser();
-			configparser.read(this.configPath); // If no error catched, indicates it's INI format
-			this.config = configparser;
-		} catch (error) {
-			if (error.name && error.name === 'MissingSectionHeaderError') {
-				// Not INI format, see if it's JSON format
-				const fs = require('fs');
-				var configData = fs.readFileSync(this.configPath, 'utf8');
-				this.config = {
-					_sections: JSON.parse(configData), // To match INI data format
-				};
+			try {
+				var configparser = new ConfigParser();
+				configparser.read(this.configPath); // If no error catched, indicates it's INI format
+				this.config = configparser;
+			} catch (error) {
+				if (error.name && error.name === 'MissingSectionHeaderError') {
+					// Not INI format, see if it's JSON format
+					const fs = require('fs');
+					var configData = fs.readFileSync(this.configPath, 'utf8');
+					this.config = {
+						_sections: JSON.parse(configData), // To match INI data format
+					};
+				}
 			}
-		}
 
-		if (this.config) this.updateConfigValues();
+			if (this.config) this.updateConfigValues();
+		}
 	}
 
 	updateConfigValues() {


### PR DESCRIPTION
Wrap `require('fs')` statement inside `typeof window` check to ensure it
is in node environment. We have an issue where the browser environment trying to
resolve `fs` which is only available in node environment. By placing the
relevant node logic inside the `typeof window` check, the node logic
will be pruned due to `typeof window === 'undefined'` being false in
browser environment.

@jasonpearson @timsmithgenesys