### PR TITLE
Update Configuration imports to ES6

### DIFF
--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -63,6 +63,7 @@ declare class Configuration {
 	logger: Logger;
 	config: any;
 	setEnvironment(environment: string): void;
+	setConfigPath(path: string): void;
 }
 
 declare class Logger {

--- a/build/src/purecloud-platform-client-v2/configuration.js
+++ b/build/src/purecloud-platform-client-v2/configuration.js
@@ -1,3 +1,7 @@
+import ConfigParser from 'configparser';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import Logger from './logger.js';
 
 class Configuration {
@@ -23,8 +27,6 @@ class Configuration {
 		if (typeof window !== 'undefined') {
 			this.configPath = '';
 		} else {
-			const os = require('os');
-			const path = require('path');
 			this.configPath = path.join(os.homedir(), '.genesyscloudjavascript', 'config');
 		}
 		this.refresh_access_token = true;
@@ -49,7 +51,6 @@ class Configuration {
 
 			if (this.live_reload_config && this.live_reload_config === true) {
 				try {
-					const fs = require('fs');
 					fs.watchFile(this.configPath, { persistent: false }, (eventType, filename) => {
 						this.updateConfigFromFile();
 						if (!this.live_reload_config) {
@@ -78,7 +79,6 @@ class Configuration {
 			// Please don't remove the typeof window === 'undefined' check here!
 			// This safeguards the browser environment from using `fs`, which is only
 			// available in node environment.
-			const ConfigParser = require('configparser');
 
 			try {
 				var configparser = new ConfigParser();
@@ -87,7 +87,6 @@ class Configuration {
 			} catch (error) {
 				if (error.name && error.name === 'MissingSectionHeaderError') {
 					// Not INI format, see if it's JSON format
-					const fs = require('fs');
 					var configData = fs.readFileSync(this.configPath, 'utf8');
 					this.config = {
 						_sections: JSON.parse(configData), // To match INI data format


### PR DESCRIPTION
Reported in https://developer.genesys.cloud/forum/t/cant-use-purecloud-platform-client-v2-with-node-js-typescript/12151/10

> ReferenceError: You are trying to `import` a file after the Jest environment has been torn down

This warning reveals itself when live reloading is enabled and the context of the runtime is Node.js (not a browser). Recommended resolutions did not appear to have an effect on resolving the warning. The warning leads to having an impact on the success of Jest executions in CI/CD tooling.

In this commit:
- Update configuration.js to use ES6 imports. Removes runtime ESM require() from functions. Including the TS config for `allowSyntheticDefaultImports` in a consuming application does not appear to resolve the warning.
- Update Add TS definition for Configuration.setConfigPath. This definition was missing, keeping TS projects from being able to define a config path. However, the inline require() usage is ultimately the root of the issue.